### PR TITLE
マウススクロールのロジックを改善、矢印キーでの移動にも対応

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -6,150 +6,168 @@ import pluginVue from 'eslint-plugin-vue'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
-export default defineConfig([
-  // directory
-  {
-    ignores: ['**/.output/**', '**/.wxt/**', '**/node_modules/**'],
-  },
+export default defineConfig(
+  [
+    // directory
+    {
+      ignores: ['**/.output/**', '**/.wxt/**', '**/node_modules/**'],
+    },
 
-  // JS / TS / Vue
-  tseslint.configs.recommended,
-  {
-    files: ['**/*.{js,mjs,cjs,ts,mts,cts,vue}'],
-    plugins: { js },
-    extends: ['js/recommended'],
-    languageOptions: {
-      globals: globals.node,
-      parserOptions: {
-        ecmaVersion: 'latest',
-        sourceType: 'module',
+    // JS / TS / Vue
+    tseslint.configs.recommended,
+    {
+      files: ['**/*.{js,mjs,cjs,ts,mts,cts,vue}'],
+      plugins: { js },
+      extends: ['js/recommended'],
+      languageOptions: {
+        globals: globals.node,
+        parserOptions: {
+          ecmaVersion: 'latest',
+          sourceType: 'module',
+        },
+      },
+      rules: {
+
+        // JSルール
+        'comma-dangle': [
+          'error',
+          {
+            arrays: 'always-multiline',
+            objects: 'always-multiline',
+            imports: 'always-multiline',
+            exports: 'always-multiline',
+            functions: 'never',
+          },
+        ],
+        'brace-style': ['error', 'stroustrup'],
+        '@typescript-eslint/no-unused-vars': [
+          'error',
+          {
+            args: 'all',
+            argsIgnorePattern: '^_',
+            caughtErrors: 'all',
+            caughtErrorsIgnorePattern: '^_',
+            destructuredArrayIgnorePattern: '^_',
+            varsIgnorePattern: '^_',
+            ignoreRestSiblings: true,
+          },
+        ],
+        'no-unused-vars': 'off',
+        'no-undef': 'off',
+        'no-trailing-spaces': 'warn',
+        quotes: ['error', 'single'],
+        'function-paren-newline': ['error', 'consistent'],
+        'no-multiple-empty-lines': ['error', { max: 1, maxEOF: 0, maxBOF: 0 }],
+        semi: ['error', 'never', { beforeStatementContinuationChars: 'never' }],
+        'semi-spacing': ['error', { after: true, before: false }],
+        'semi-style': ['error', 'first'],
+        'no-extra-semi': 'error',
+        'no-unexpected-multiline': 'error',
+        'no-unreachable': 'error',
+        'prefer-const': 'off',
+        'quote-props': ['error', 'as-needed'], //''で囲む必要のないプロパティは'を外す
+        '@typescript-eslint/consistent-type-imports':
+          ['error',
+            { prefer: 'type-imports', fixStyle: 'separate-type-imports' }],
       },
     },
-    rules: {
 
-      // JSルール
-      'comma-dangle': [
-        'error',
-        {
-          arrays: 'always-multiline',
-          objects: 'always-multiline',
-          imports: 'always-multiline',
-          exports: 'always-multiline',
-          functions: 'never',
-        },
-      ],
-      'brace-style': ['error', 'stroustrup'],
-      'no-unused-vars': 'off',
-      'no-undef': 'off',
-      'no-trailing-spaces': 'warn',
-      quotes: ['error', 'single'],
-      'function-paren-newline': ['error', 'consistent'],
-      'no-multiple-empty-lines': ['error', { max: 1, maxEOF: 0, maxBOF: 0 }],
-      semi: ['error', 'never', { beforeStatementContinuationChars: 'never' }],
-      'semi-spacing': ['error', { after: true, before: false }],
-      'semi-style': ['error', 'first'],
-      'no-extra-semi': 'error',
-      'no-unexpected-multiline': 'error',
-      'no-unreachable': 'error',
-      'prefer-const': 'off',
-      'quote-props': ['error', 'as-needed'], //''で囲む必要のないプロパティは'を外す
-      '@typescript-eslint/consistent-type-imports':
-        ['error',
-          { prefer: 'type-imports', fixStyle: 'separate-type-imports' }],
+    // vue
+    pluginVue.configs['flat/recommended'],
+    {
+      files: ['**/*.vue'], languageOptions: { parserOptions: { parser: tseslint.parser } },
+      rules: {
+        // Vueカスタムルール
+        'vue/no-root-v-if': 'warn',
+        'vue/no-multiple-template-root': 'off',
+        'vue/multi-word-component-names': 'off',
+        'vue/require-v-for-key': 'error',
+        'vue/no-use-v-if-with-v-for': 'error',
+        'vue/no-parsing-error': 'off',
+        'vue/block-tag-newline': 'off',
+        'vue/singleline-html-element-content-newline': 'off',
+        'vue/no-irregular-whitespace': 'error',
+        'vue/require-default-prop': 'warn',
+        'vue/html-indent': 'off',
+        'vue/multiline-html-element-content-newline': 0,
+        'vue/html-closing-bracket-newline': 0,
+        'vue/max-attributes-per-line': 'off',
+        'vue/html-self-closing': 'off',
+        'vue/first-attribute-linebreak': 'off',
+        'vue/static-class-names-order': 'error',
+      },
     },
-  },
 
-  // vue
-  pluginVue.configs['flat/recommended'],
-  {
-    files: ['**/*.vue'], languageOptions: { parserOptions: { parser: tseslint.parser } },
-    rules: {
-      // Vueカスタムルール
-      'vue/no-root-v-if': 'warn',
-      'vue/no-multiple-template-root': 'off',
-      'vue/multi-word-component-names': 'off',
-      'vue/require-v-for-key': 'error',
-      'vue/no-use-v-if-with-v-for': 'error',
-      'vue/no-parsing-error': 'off',
-      'vue/block-tag-newline': 'off',
-      'vue/singleline-html-element-content-newline': 'off',
-      'vue/no-irregular-whitespace': 'error',
-      'vue/require-default-prop': 'warn',
-      'vue/html-indent': 'off',
-      'vue/multiline-html-element-content-newline': 0,
-      'vue/html-closing-bracket-newline': 0,
-      'vue/max-attributes-per-line': 'off',
-      'vue/html-self-closing': 'off',
-      'vue/first-attribute-linebreak': 'off',
-      'vue/static-class-names-order': 'error',
-    },
-  },
-
-  // eslint-plugin-import
-  {
-    plugins: {
-      import: pluginImport,
-    },
-    rules: {
-      'import/newline-after-import': 'error',
-      'import/order': [
-        'error',
-        {
-          groups: [
-            'builtin',           // Node.js組み込みモジュール (例: 'fs', 'path')
-            'external',          // 外部ライブラリ/npmパッケージ
-            'internal',          // プロジェクト内の絶対パスインポート/エイリアス (例: '@/components')
-            'parent',            // 親ディレクトリへの相対パス (例: '../')
-            'sibling',           // 兄弟ファイルへの相対パス (例: './')
-            'index',             // 同じディレクトリのindexファイル (例: './')
-            'object',            // オブジェクトインポート (非推奨な場合あり)
-          ],
-          'newlines-between': 'always', // グループ間に空行を強制
-          alphabetize: {
-            order: 'asc',             // 各グループ内でアルファベット順にソート
-            caseInsensitive: true,
-            orderImportKind: 'desc', // 同じ
-          },
-          pathGroups: [
-            {
-              pattern: '@/**',
-              group: 'internal',
+    // eslint-plugin-import
+    {
+      plugins: {
+        import: pluginImport,
+      },
+      rules: {
+        'import/newline-after-import': 'error',
+        'import/order': [
+          'error',
+          {
+            groups: [
+              'builtin',           // Node.js組み込みモジュール (例: 'fs', 'path')
+              'external',          // 外部ライブラリ/npmパッケージ
+              'internal',          // プロジェクト内の絶対パスインポート/エイリアス (例: '@/components')
+              'parent',            // 親ディレクトリへの相対パス (例: '../')
+              'sibling',           // 兄弟ファイルへの相対パス (例: './')
+              'index',             // 同じディレクトリのindexファイル (例: './')
+              'object',            // オブジェクトインポート (非推奨な場合あり)
+            ],
+            'newlines-between': 'always', // グループ間に空行を強制
+            alphabetize: {
+              order: 'asc',             // 各グループ内でアルファベット順にソート
+              caseInsensitive: true,
+              orderImportKind: 'desc', // 同じ
             },
-          ],
-          pathGroupsExcludedImportTypes: ['builtin'],
-        },
-      ],
+            pathGroups: [
+              {
+                pattern: '@/**',
+                group: 'internal',
+              },
+            ],
+            pathGroupsExcludedImportTypes: ['builtin'],
+          },
+        ],
+      },
     },
-  },
 
-  // @stylistic/eslint-plugin
-  {
-    plugins: {
-      '@stylistic': stylistic,
-    },
-    rules: {
-      '@stylistic/member-delimiter-style': [
-        'error',
-        {
-          multiline: {
-            delimiter: 'none',    // すべての行で何もなし
-            requireLast: true,    // 最終行のデリミタ（セミコロン、カンマ）を禁止
-          },
-          singleline: {
-            delimiter: 'comma',
-            requireLast: false,
-          },
-          // interface, type, class/interface/type literalなど、
-          // 詳細な型定義の区切り文字をより細かく制御するためのオーバーライドも可能です。
-          overrides: {
-            interface: {
-              multiline: {
-                requireLast: false, // interfaceの最後のプロパティのセミコロンを禁止
+    // @stylistic/eslint-plugin
+    {
+      plugins: {
+        '@stylistic': stylistic,
+      },
+      rules: {
+        '@stylistic/member-delimiter-style': [
+          'error',
+          {
+            multiline: {
+              delimiter: 'none',    // すべての行で何もなし
+              requireLast: true,    // 最終行のデリミタ（セミコロン、カンマ）を禁止
+            },
+            singleline: {
+              delimiter: 'comma',
+              requireLast: false,
+            },
+            // interface, type, class/interface/type literalなど、
+            // 詳細な型定義の区切り文字をより細かく制御するためのオーバーライドも可能です。
+            overrides: {
+              interface: {
+                multiline: {
+                  requireLast: false, // interfaceの最後のプロパティのセミコロンを禁止
+                },
               },
             },
           },
-        },
-      ],
+        ],
+
+        'array-element-newline': ['error', 'consistent'],
+        'function-paren-newline': ['error', 'consistent'],
+        'function-call-argument-newline': ['error', 'never'],
+      },
     },
-  },
-])
+  ]
+)

--- a/src/components/popup/Popup.vue
+++ b/src/components/popup/Popup.vue
@@ -1,35 +1,26 @@
 <script setup lang="ts">
-import { IconGear } from '@iconify-prerendered/vue-pepicons-pop'
+import { useTabs } from '@/composables/useTabs'
 
-import UserOption from '@/components/useroption/UserOption.vue'
-
-export interface TabType {
-  key: StorageItemKey
-  name: 'Option'
-}
-
-const tabs: TabType[] = [
-  { key: 'local:Option', name: 'Option' },
-]
-
-const activeTab = ref<TabType>(tabs[0])
+const { tabs, activeTab, updateState } = useTabs()
 </script>
 
 <template>
-  <div class="tab-container">
-    <div class="border-b border-gray-200 dark:border-gray-700">
+  <div class="h-[500px]  tab-container  w-[460px]">
+    <div>
       <ul class="dark:text-gray-400 flex flex-wrap font-medium text-gray-500 text-lg">
-        <li v-for="tab in tabs" :key="tab.key" class="me-2" @click="activeTab = tab">
-          <a href="#"
-            class="border-b-2 border-transparent dark:hover:text-gray-300 hover:border-gray-300 hover:text-gray-600 inline-flex items-center justify-center p-4 rounded-t-lg">
-            <IconGear v-if="tab.name === `Option`" class="inline-block mr-2" />
+        <li v-for="(tab, index) in tabs" :key="tab.name" class="me-2" @click="activeTab = tab">
+          <button type="button"
+            class="border-b-2 border-transparent dark:hover:text-gray-300 hover:border-gray-300 hover:text-gray-600 inline-flex items-center justify-center p-4"
+            :class="{ 'border-blue-200 text-blue-300 dark:text-blue-200': activeTab.name === tab.name }"
+            @click="updateState({ type: 'update', value: index })">
+            <component :is="tab.icon" class="inline-block mr-2" />
             {{ tab.name }}
-          </a>
+          </button>
         </li>
       </ul>
-      <div class="px-2">
-        <UserOption v-if="activeTab.name === `Option`" :model-value="activeTab" />
-      </div>
+      <KeepAlive>
+        <component :is="activeTab.component" class="tabs__content" />
+      </KeepAlive>
     </div>
   </div>
 </template>

--- a/src/components/useroption/RangeInput.vue
+++ b/src/components/useroption/RangeInput.vue
@@ -18,7 +18,7 @@ const { internalValue, handleUpdate } = useRangeInput(props, emit)
 </script>
 
 <template>
-  <div class="flex font-bold ml-1 mt-2 text-sm">
+  <div class="flex my-1">
     <slot></slot>
     <input type="range" :value="internalValue" :min="min" :max="max" :step="step" :disabled="disabled" class="ml-auto"
       @input="handleUpdate('input', $event)" @change="handleUpdate('change', $event)" />

--- a/src/components/useroption/UserOption.vue
+++ b/src/components/useroption/UserOption.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import useUserOption from '@/composables/useUserOption'
 import type { BooleanKeys, NumberKeys } from '@/composables/useUserOption'
 
@@ -6,10 +8,6 @@ import RangeInput from './RangeInput.vue'
 
 const { state, updateState } = useUserOption()
 
-/**
- * 💡 すべてのオプション設定を定義するための共通インターフェース
- * RangeInputのプロパティを 'range' タイプに追加しています
- */
 interface BaseOption {
   label: string
   key: BooleanKeys | NumberKeys
@@ -26,41 +24,57 @@ interface RangeOption extends BaseOption {
   min: number
   max: number
   step: number
-  // RangeInputの :disabled に対応するキー
   disabledKey?: BooleanKeys
   updateTrigger: 'input' | 'change'
-  unit: string // 表示用の単位
+  unit: string
 }
 
-type OptionItem = BoolOption | RangeOption;
+type OptionItem = BoolOption | RangeOption
 
-// 💡 新しい単一のオプションリスト
+// --------------------------------------------
+// オプションリスト
+// --------------------------------------------
 const optionsList: OptionItem[] = [
-  // 1. マウスホイールを反転する (Boolean)
   {
     type: 'bool',
     key: 'wheelReverse',
     label: 'マウスホイールを反転する',
   },
-  // 2. スクロール量 (Range) - wheelReverseと関連
   {
     type: 'range',
-    key: 'scrollAmount',
-    label: 'スクロール量',
-    min: 10,
-    max: 2000,
-    step: 10,
-    updateTrigger: 'change',
-    unit: 'px',
+    key: 'wheelScrollLines',
+    label: 'マウスホイール1回の移動行数',
+    min: 1,
+    max: 20,
+    step: 1,
+    updateTrigger: 'input',
+    unit: '行',
   },
-
-  // 3. 本文の高さを調整する (Boolean)
+  {
+    type: 'bool',
+    key: 'wheelCtrlSwap',
+    label: 'Ctrl+ホイールの動作を通常と入れ替える',
+  },
+  {
+    type: 'range',
+    key: 'arrowScrollLines',
+    label: '矢印キー1回の移動行数',
+    min: 1,
+    max: 20,
+    step: 1,
+    updateTrigger: 'input',
+    unit: '行',
+  },
+  {
+    type: 'bool',
+    key: 'arrowCtrlSwap',
+    label: 'Ctrl+矢印キーの動作を通常と入れ替える',
+  },
   {
     type: 'bool',
     key: 'expandHeight',
     label: '本文領域の高さを調整する',
   },
-  // 4. 本文領域の高さ (Range) - expandHeightと関連
   {
     type: 'range',
     key: 'viewportHeight',
@@ -68,12 +82,10 @@ const optionsList: OptionItem[] = [
     min: 2,
     max: 100,
     step: 2,
-    disabledKey: 'expandHeight', // expandHeight が false の場合に無効化
+    disabledKey: 'expandHeight',
     updateTrigger: 'input',
     unit: '%',
   },
-
-  // 5. その他の Boolean オプション (続けて配置)
   {
     type: 'bool',
     key: 'fixedOnload',
@@ -91,19 +103,37 @@ const optionsList: OptionItem[] = [
   },
 ] as const
 
-// 💡 型ガード関数 (テンプレート内で安全に型を判別するため)
 const isRangeOption = (option: OptionItem): option is RangeOption => option.type === 'range'
+
+// --------------------------------------------
+// 💬 説明テキスト（リアルタイム表示）
+// --------------------------------------------
+const wheelDescription = computed(() => {
+  if (!state.value) return ''
+  const { wheelCtrlSwap } = state.value
+  return wheelCtrlSwap
+    ? '現在: 通常ホイールでページ送り、Ctrl+ホイールで行スクロール'
+    : '現在: 通常ホイールで行スクロール、Ctrl+ホイールでページ送り'
+})
+
+const arrowDescription = computed(() => {
+  if (!state.value) return ''
+  const { arrowCtrlSwap } = state.value
+  return arrowCtrlSwap
+    ? '現在: 通常矢印キーでページ送り、Ctrl+矢印キーで行スクロール'
+    : '現在: 通常矢印キーで行スクロール、Ctrl+矢印キーでページ送り'
+})
 </script>
 
 <template>
-  <div class="box-border flex flex-col h-[280px] w-[320px]">
+  <div class="flex flex-col px-2">
     <h2 class="dark:text-gray-600 flex gap-2 mb-4 mt-1 text-2xl text-gray-700">
       <span>User Option Management</span>
     </h2>
 
-    <div v-if="state" class="flex flex-col gap-2 grow">
+    <div v-if="state" class="flex flex-col gap-2 grow text-sm">
       <template v-for="option in optionsList" :key="option.key">
-        <div v-if="option.type === 'bool'" class="cursor-pointer flex gap-1 items-center select-none text-sm">
+        <div v-if="option.type === 'bool'" class="cursor-pointer flex gap-1 items-center select-none">
           <label class="cursor-pointer flex gap-1 items-center">
             <input type="checkbox"
               class="appearance-none bg-white border-2 border-black checked:bg-indigo-600 h-4 rounded shrink-0 w-4"
@@ -118,6 +148,13 @@ const isRangeOption = (option: OptionItem): option is RangeOption => option.type
           {{ `${option.label}: ${state[option.key]}${option.unit}` }}
         </RangeInput>
 
+        <!-- 💡 動作説明行を挿入 -->
+        <p v-if="option.key === 'wheelCtrlSwap'" class="-mt-1 mb-2 ml-5 text-gray-500 text-xs">
+          {{ wheelDescription }}
+        </p>
+        <p v-if="option.key === 'arrowCtrlSwap'" class="-mt-1 mb-2 ml-5 text-gray-500 text-xs">
+          {{ arrowDescription }}
+        </p>
       </template>
     </div>
   </div>

--- a/src/composables/useNovelScroll.ts
+++ b/src/composables/useNovelScroll.ts
@@ -1,50 +1,29 @@
 // useNovelScroll.ts
 
-import { useWindowScrollLock } from '@prhm0998/shared/composables'
-import { getFixedElementsTotalHeight, scrollWithFixedOffset, smoothScroll } from '@prhm0998/shared/utils'
+import { flexibleClamp, getFixedElementsTotalHeight, scrollWithFixedOffset, smoothScroll } from '@prhm0998/shared/utils'
 import { useThrottleFn } from '@vueuse/core'
 import type { Ref } from 'vue'
 
-import type { UserOption } from './useUserOption'
+export function useNovelScroll(pNovelRef: Ref<HTMLElement | null>) {
 
-/**
- * 本文のカスタムスクロールとイベント処理を提供するComposables
- * @param pNovelRef 本文要素のRef
- * @param optionRef ユーザーオプションのRef
- */
-export function useNovelScroll(pNovelRef: Ref<HTMLElement | null>, optionRef: Ref<UserOption>) {
-  /**
-   * 横書き領域のスクロールは前提がややこしいので注意
-   * まず、右から左←へスクロールするとき要素の座標はマイナス方向に進みます
-   * つまり、マウスホイール/スクロールなどで"進む"ときは座標に対して負の値を加算します
-   * 逆に"戻る"ときは座標に対して正の値を加算します
-   */
-  const { lockScroll, unlockScroll } = useWindowScrollLock()
+  const { state: userOption } = useUserOption()
 
-  // スムーススクロールのロジックをスロットル化
-  const throttledSmoothScroll = useThrottleFn(
-    async (el: HTMLElement, amount: number) => {
-      await smoothScroll(el, amount, {
-        direction: 'horizontal',
-        mode: 'speed',
-        speedPerMs: 20,
-        timeout: 2000,
-        onStart: () => lockScroll(),
-        onFinish: () => unlockScroll(),
-      })
-    },
-    200
-  )
+  // 行移動の管理用
+  const novelRowsSet = ref(new Set<HTMLElement>())
+  const novelRows = computed(() => [...novelRowsSet.value])
+  const insertRowElm = (el: HTMLElement) => novelRowsSet.value.add(el)
 
-  function onWheelScroll(el: HTMLElement) {
-    return function (e: WheelEvent) {
-      const { wheelReverse, scrollAmount } = optionRef.value
-      const direction = e.deltaY > 0 ? 1 : -1
-      const baseAmount = wheelReverse ? scrollAmount : -scrollAmount
-      const amount = baseAmount * direction
-      throttledSmoothScroll(el, amount)
-      e.preventDefault()
-    }
+  function attachNovelEvents() {
+    const pNovel = pNovelRef.value
+    if (!pNovel) return
+
+    const wheelHandler = onWheelScroll()
+    const dblClickHandler = onDoubleClick(pNovel)
+    const keyHandler = onKeyScroll()
+
+    pNovel.addEventListener('wheel', wheelHandler)
+    pNovel.addEventListener('dblclick', dblClickHandler)
+    window.addEventListener('keydown', keyHandler)
   }
 
   function onDoubleClick(el: HTMLElement) {
@@ -53,15 +32,164 @@ export function useNovelScroll(pNovelRef: Ref<HTMLElement | null>, optionRef: Re
       scrollWithFixedOffset(el, getFixedElementsTotalHeight())
     }
   }
-  function attachNovelEvents() {
-    const pNovel = pNovelRef.value
-    if (!pNovel) return
-    pNovel.addEventListener('wheel', onWheelScroll(pNovel))
-    pNovel.addEventListener('dblclick', onDoubleClick(pNovel))
+
+  function onWheelScroll() {
+    return function (e: WheelEvent) {
+      const { wheelReverse, wheelScrollLines, wheelCtrlSwap } = userOption.value
+      const isScrollDown = e.deltaY > 0
+      const isCtrl = e.ctrlKey
+
+      const direction = wheelReverse
+        ? isScrollDown ? -1 : 1   // 反転: 下スクロールで-1, 上スクロールで1
+        : isScrollDown ? 1 : -1    // 通常: 下スクロールで1, 上スクロールで-1
+
+      const isSwappedCtrl = wheelCtrlSwap ? !isCtrl : isCtrl
+
+      // amount=nullはページ送り
+      const amount = isSwappedCtrl ? null : wheelScrollLines * direction
+
+      throttledScrollToRow(direction, amount)
+
+      e.preventDefault()
+    }
+  }
+
+  function onKeyScroll() {
+    return function (e: KeyboardEvent) {
+
+      const { arrowScrollLines, arrowCtrlSwap } = userOption.value
+
+      if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return
+      const direction = e.key === 'ArrowLeft' ? 1 : -1
+
+      const isCtrl = e.ctrlKey
+
+      const isSwappedCtrl = arrowCtrlSwap ? !isCtrl : isCtrl
+
+      const amount = isSwappedCtrl ? null : arrowScrollLines * direction
+
+      throttledScrollToRow(direction, amount)
+
+      e.preventDefault()
+    }
+  }
+
+  const throttledScrollToRow = useThrottleFn(async (...args: Parameters<typeof scrollToTargetRow>) => {
+    await scrollToTargetRow(...args)
+  }, 200)
+
+  async function scrollToTargetRow(direction: 1 | -1, amount?: number | null) {
+    const search = getVisibleRowRange()
+    if (!search) {
+      return
+    }
+
+    let targetIndex: number
+    // 現在は end=ページ戻りの判定用, 将来的にscroll後のターゲットの位置の指定にするつもり
+    let block: 'start' | 'end'
+
+    if (amount) {
+      const [first] = search
+      targetIndex = flexibleClamp(first + amount, {
+        min: 0,
+        max: novelRows.value.length - 1,
+      })
+      block = 'start'
+    }
+
+    else {
+      if (direction === 1) {
+        const [, last] = search
+        targetIndex = flexibleClamp(last + 1, {
+          min: 0,
+          max: novelRows.value.length - 1,
+        })
+        block = 'start'
+      }
+      else {
+        const [first] = search
+        targetIndex = flexibleClamp(first - 1, {
+          min: 0,
+          max: novelRows.value.length - 1,
+        })
+        block = 'end'
+      }
+    }
+
+    if (pNovelRef.value) {
+      performHorizontalScroll(pNovelRef.value, novelRows.value[targetIndex], block)
+    }
+  }
+
+  async function performHorizontalScroll(outer: HTMLElement, target: HTMLElement, block: 'start' | 'end') {
+    if (block === 'start') {
+      /**
+       * scrollElement, targetElementから移動量を計算します
+      */
+      const leftDistance = outer.offsetWidth - target.getBoundingClientRect().right
+      smoothScroll(outer, leftDistance * -1, {
+        mode: 'duration',
+        duration: 10,
+        direction: 'horizontal',
+      })
+    }
+    else {
+      // 「1ページ分戻る」はスクロールエリアのサイズ分戻る
+      smoothScroll(outer, outer.offsetWidth, {
+        mode: 'duration',
+        duration: 10,
+        direction: 'horizontal',
+      })
+
+    }
+  }
+
+  /**
+   * 連続した可視/非可視要素の配列から
+   * [最初に見えている要素のindex, 最後に見えている要素のindex] を返します
+   *
+   * 配列中の可視要素は連続した一つの塊であることを前提とします
+   */
+  function getVisibleRowRange(): [number, number] | null {
+    const n = novelRows.value.length
+    if (n === 0) return null
+
+    let startIndex = 0
+
+    // 最初に見えている要素のindexの探索
+    let firstVisibleIndex = null
+    for (let i = startIndex; i < n; i++) {
+      const current = novelRows.value[i]
+      if (isElementInView(current, {
+        ignoreVertical: true,
+      })) {
+        firstVisibleIndex = i
+        break
+      }
+    }
+
+    if (firstVisibleIndex === null) return null
+
+    // 最後に見えている要素のindexの探索
+    let lastVisibleIndex = firstVisibleIndex
+    for (let i = firstVisibleIndex; i < n; i++) {
+      const current = novelRows.value[i]
+      if (isElementInView(current, {
+        // 最後の行は大体8割見えていれば読めるため、水平方向は甘めに判定する
+        ignoreVertical: true,
+        minHorizontalRatio: 0.8,
+      })) {
+        lastVisibleIndex = i
+      }
+      else {
+        break
+      }
+    }
+    return [firstVisibleIndex, lastVisibleIndex]
   }
 
   return {
     attachNovelEvents,
-    // onWheelScroll, // 必要なら公開
+    insertRowElm,
   }
 }

--- a/src/composables/useRangeInput.ts
+++ b/src/composables/useRangeInput.ts
@@ -1,3 +1,5 @@
+// useRangeInput.ts
+
 type RangeInputProps = {
   value: number
   min: number

--- a/src/composables/useTabs.ts
+++ b/src/composables/useTabs.ts
@@ -1,0 +1,65 @@
+// useTabs.ts
+
+import { IconGear } from '@iconify-prerendered/vue-pepicons-pop'
+
+import UserOption from '@/components/useroption/UserOption.vue'
+
+export interface TabType {
+  name: 'Option'
+  icon: Component
+  component: Component
+}
+
+export type TabsState = number
+
+export interface Tabs {
+  current: TabsState
+  tabType: TabType
+}
+
+export type TabsUpdateEvent =
+  | { type: 'update', value: number }
+
+type UpdateStateFn<S, E> = (
+  state: Ref<S>,
+  event: E,
+) => void
+
+const updateStateLogic: UpdateStateFn<TabsState, TabsUpdateEvent> = (
+  state,
+  event
+) => {
+  const { type } = event
+
+  switch (type) {
+    case 'update': {
+      const { value } = event
+      if (typeof value === 'number')
+        state.value = value
+      break
+    }
+    default:
+      break
+  }
+}
+
+export function useTabs() {
+  const state = ref(0)
+
+  const tabs: TabType[] = [
+    { name: 'Option', icon: IconGear, component: markRaw(UserOption) },
+  ]
+
+  function updateState(event: TabsUpdateEvent) {
+    updateStateLogic(state, event)
+  }
+
+  const activeTab = computed(() => tabs[state.value])
+
+  return {
+    current: state,
+    tabs,
+    activeTab,
+    updateState,
+  }
+}

--- a/src/entrypoints/popup/App.vue
+++ b/src/entrypoints/popup/App.vue
@@ -5,20 +5,3 @@ import Popup from '@/components/popup/Popup.vue'
 <template>
   <Popup></Popup>
 </template>
-
-<style scoped>
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-
-.logo:hover {
-  filter: drop-shadow(0 0 2em #54bc4ae0);
-}
-
-.logo.vue:hover {
-  filter: drop-shadow(0 0 2em #42b883aa);
-}
-</style>

--- a/src/entrypoints/tategaki.content/index.ts
+++ b/src/entrypoints/tategaki.content/index.ts
@@ -21,8 +21,8 @@ export default defineContentScript({
     /**
      * 単発小説の場合URLのみでは判断がつかないため、それっぽい要素を探索する
      */
-    const body = await waitElement('.p-novel__body', { signal: AbortSignal.timeout(2000) })
-      .catch(null)
+    const body = await waitElement('.p-novel__body', { signal: AbortSignal.timeout(1000) })
+      .catch(() => { })
     if (!body) return
     const ui = createIntegratedUi(ctx, {
       position: 'inline',

--- a/src/utils/getVisibilityRatios.ts
+++ b/src/utils/getVisibilityRatios.ts
@@ -1,0 +1,28 @@
+export type VisibilityRatios = {
+  horizontal: number
+  vertical: number
+}
+/**
+ * 要素の可視率を計算する
+ * @returns 横方向・縦方向それぞれの可視率（0〜1）
+ */
+export function getVisibilityRatios(element: Element): VisibilityRatios {
+  const rect = element.getBoundingClientRect()
+  const viewportHeight = window.innerHeight || document.documentElement.clientHeight
+  const viewportWidth = window.innerWidth || document.documentElement.clientWidth
+
+  const visibleWidth = Math.min(rect.right, viewportWidth) - Math.max(rect.left, 0)
+  const visibleHeight = Math.min(rect.bottom, viewportHeight) - Math.max(rect.top, 0)
+
+  const horizontal = Math.max(0, Math.min(visibleWidth / rect.width, 1))
+  const vertical = Math.max(0, Math.min(visibleHeight / rect.height, 1))
+
+  //if (horizontal < 1) {
+  //  console.log('要素', element)
+  //  console.log('縦方向の可視率', vertical)
+  //  console.log('横方向の可視率', horizontal)
+  //
+  //}
+
+  return { horizontal, vertical }
+}

--- a/src/utils/isElementInView.ts
+++ b/src/utils/isElementInView.ts
@@ -1,0 +1,50 @@
+import { getVisibilityRatios } from '@/utils/getVisibilityRatios'
+
+export type InViewOptions = {
+  /** 要素の最小水平可視率（0〜1） */
+  minHorizontalRatio?: number
+  /** 要素の最小垂直可視率（0〜1） */
+  minVerticalRatio?: number
+  /** 水平方向の可視率判定を無視 */
+  ignoreHorizontal?: boolean
+  /** 垂直方向の可視率判定を無視 */
+  ignoreVertical?: boolean
+}
+
+/**
+ * 要素がビューポート内で完全または指定割合以上表示されているかを判定します。
+ *
+ * @param {Element} element - 判定対象のDOM要素
+ * @param {InViewOptions} [options] - 表示率や無視設定などのオプション
+ * @returns {boolean} 指定条件を満たしている場合は `true`
+ */
+export function isElementInView(element: Element, options: InViewOptions = {}): boolean {
+  const { horizontal, vertical } = getVisibilityRatios(element)
+  const rect = element.getBoundingClientRect()
+
+  const viewportHeight = window.innerHeight || document.documentElement.clientHeight
+  const viewportWidth = window.innerWidth || document.documentElement.clientWidth
+
+  const isCompletelyVisible =
+    rect.top >= 0 &&
+    rect.bottom <= viewportHeight &&
+    rect.left >= 0 &&
+    rect.right <= viewportWidth
+
+  // オプション未指定時は完全表示のみチェック
+  const noRatioOptions =
+    options.minHorizontalRatio == null &&
+    options.minVerticalRatio == null &&
+    !options.ignoreHorizontal &&
+    !options.ignoreVertical
+
+  if (noRatioOptions) return isCompletelyVisible
+
+  const horizontalOk =
+    options.ignoreHorizontal || horizontal >= (options.minHorizontalRatio ?? 1)
+
+  const verticalOk =
+    options.ignoreVertical || vertical >= (options.minVerticalRatio ?? 1)
+
+  return horizontalOk && verticalOk
+}

--- a/src/utils/scrollHirizontalAmountToElement.ts
+++ b/src/utils/scrollHirizontalAmountToElement.ts
@@ -1,0 +1,74 @@
+export function scrollHorizontalAmountToElement(scrollEl: HTMLElement, targetEl: HTMLElement, inlineOption: string) {
+  const isRtl = getComputedStyle(scrollEl).direction === 'rtl'
+
+  // スクロール可能な最大幅（常に正の値）
+  const maxScroll = scrollEl.scrollWidth - scrollEl.clientWidth
+
+  // LTR環境では、前回の修正されたロジックを使用 (offsetLeft基準)
+  if (!isRtl) {
+    let targetOffsetLeft = targetEl.offsetLeft
+    const scrollWidth = scrollEl.offsetWidth
+    const targetWidth = targetEl.offsetWidth
+    let targetScrollLeft
+
+    switch (inlineOption) {
+      case 'start':
+        targetScrollLeft = targetOffsetLeft
+        break
+      case 'end':
+        targetScrollLeft = targetOffsetLeft - (scrollWidth - targetWidth)
+        break
+      case 'center':
+        targetScrollLeft = targetOffsetLeft - ((scrollWidth / 2) - (targetWidth / 2))
+        break
+      default:
+        targetScrollLeft = scrollEl.scrollLeft
+    }
+    return Math.max(0, Math.min(targetScrollLeft, maxScroll))
+  }
+
+  // -----------------------------------------------------------------
+  // RTL環境 (scrollLeftが負の値を取るモデル) の計算
+  // -----------------------------------------------------------------
+  const targetWidth = targetEl.offsetWidth
+  const scrollClientWidth = scrollEl.clientWidth
+
+  // targetElの右端からコンテナのスクロール可能な右端までの距離 (正の値)
+  // targetEl.offsetLeft は RTLでは信頼できないため、targetElの絶対左オフセットを使用
+  const targetAbsLeft = targetEl.offsetLeft
+
+  // targetElの絶対右オフセット (スクロールコンテナの左端からの距離)
+  const targetAbsRight = targetAbsLeft + targetWidth
+
+  let targetScrollLeft
+
+  switch (inlineOption) {
+    case 'start': // targetElの左端をコンテナの左端に合わせる (最大負の値に近い位置)
+      // LTRで 'end' に合わせた時と数値的な絶対値が一致する
+      targetScrollLeft = -(maxScroll - (scrollEl.scrollWidth - targetAbsRight - targetWidth))
+
+      // 簡略化: targetElの左端がコンテナの左端から targetAbsLeft 離れているため、
+      // その位置に合わせるには、ターゲットの左端をコンテナの左端に合わせ、
+      // コンテナの幅だけ右にずらす (-targetAbsLeft + scrollClientWidth - targetWidth)
+      targetScrollLeft = targetAbsLeft + targetWidth - scrollClientWidth
+      break
+
+    case 'end': // targetElの右端をコンテナの右端に合わせる (0に近い位置)
+      // targetElの右端の位置を0に設定する
+      targetScrollLeft = targetAbsRight - scrollEl.scrollWidth
+      break
+
+    case 'center':
+      {
+        const centerOffset = (scrollClientWidth - targetWidth) / 2
+        // 'end' の位置から centerOffset だけ左にずらす (負の値を小さくする/0に近づける)
+        targetScrollLeft = (targetAbsRight - scrollEl.scrollWidth) + centerOffset
+        break
+      }
+    default:
+      targetScrollLeft = scrollEl.scrollLeft
+  }
+
+  // 境界チェック: 0 から -maxScroll の範囲に収める
+  return targetScrollLeft
+}

--- a/src/utils/scrollVerticalAmountToElement.ts
+++ b/src/utils/scrollVerticalAmountToElement.ts
@@ -1,0 +1,42 @@
+export function scrollVerticalAmountToElement(scrollEl: HTMLElement, targetEl: HTMLElement, blockOption: string): number {
+  // 1. 基本となる差分を計算（ターゲットがコンテナ上端から現在どれだけ離れているか）
+  const targetTop = targetEl.getBoundingClientRect().top
+  const scrollContainerTop = scrollEl.getBoundingClientRect().top
+  const distanceToStart = targetTop - scrollContainerTop
+
+  // 2. 基本の TargetScrollTop (block: 'start' の値)
+  let targetScrollTop = scrollEl.scrollTop + distanceToStart
+
+  // 3. blockオプションに基づき、補正値を計算
+  switch (blockOption) {
+    case 'start':
+      // 補正なし
+      break
+
+    case 'end':
+      {
+        const heightDiffEnd = scrollEl.offsetHeight - targetEl.offsetHeight
+        // スクロールコンテナの高さ - ターゲットの高さ分だけ、上に巻き戻す
+        targetScrollTop -= heightDiffEnd
+        break
+      }
+
+    case 'center':
+      {
+        const halfHeightDiffCenter = (scrollEl.offsetHeight / 2) - (targetEl.offsetHeight / 2)
+        // スクロールコンテナの半分の高さ - ターゲットの半分の高さ分だけ、上に巻き戻す
+        targetScrollTop -= halfHeightDiffCenter
+        break
+      }
+
+    default:
+      console.error(`無効な blockOption: ${blockOption}`)
+      return scrollEl.scrollTop // 無効な場合は現在の値を返す
+  }
+
+  // スクロールの境界チェック（スクロール可能な範囲内に収める）
+  const maxScroll = scrollEl.scrollHeight - scrollEl.clientHeight
+  targetScrollTop = Math.max(0, Math.min(targetScrollTop, maxScroll))
+
+  return targetScrollTop
+}

--- a/src/utils/waitForScrollComplete.ts
+++ b/src/utils/waitForScrollComplete.ts
@@ -1,0 +1,17 @@
+export const waitForScrollComplete = (delay = 100) => {
+  return new Promise((resolve) => {
+    let resolveTimeout: NodeJS.Timeout
+    let fallback = setTimeout(() => resolve(true), delay)
+
+    const onScroll = () => {
+      clearTimeout(fallback)
+      clearTimeout(resolveTimeout)
+      resolveTimeout = setTimeout(() => {
+        window.removeEventListener('scroll', onScroll)
+        resolve(true)
+      }, delay)
+    }
+
+    window.addEventListener('scroll', onScroll)
+  })
+}


### PR DESCRIPTION
縦書きページ内の移動をpx単位から行単位になるようにロジックを変更

追加した操作とオプション
ホイールで指定行移動
CTRL+ホイールでページ移動
CTRLの扱いを反転
矢印キーで指定行移動
CTRL+矢印キーでページ移動
CTRLの扱いを反転 (※デフォルトでON)

